### PR TITLE
Update PinnedSectionListView.java

### DIFF
--- a/library/src/com/hb/views/PinnedSectionListView.java
+++ b/library/src/com/hb/views/PinnedSectionListView.java
@@ -188,6 +188,10 @@ public class PinnedSectionListView extends ListView {
 
 		int heightMode, heightSize;
 		if (layoutParams == null) { // take care for missing layout parameters
+			layoutParams = new ListView.LayoutParams(
+				ListView.LayoutParams.MATCH_PARENT,
+				ListView.LayoutParams.WRAP_CONTENT);
+			pinnedView.setLayoutParams(layoutParams);
 			heightMode = MeasureSpec.AT_MOST;
 			heightSize = getHeight();
 		} else {


### PR DESCRIPTION
fix bug:
when pinnedView returned by getView() didn't setLayoutParam(), then in some android version, the use of mLayoutParams in pinnedView.measure() will cause a null pointer exception.
