### PR TITLE
Attempt to fix the overlapping section headers when the list view reach ...

### DIFF
--- a/library/src/com/hb/views/PinnedSectionListView.java
+++ b/library/src/com/hb/views/PinnedSectionListView.java
@@ -278,9 +278,14 @@ public class PinnedSectionListView extends ListView {
 
 	int findFirstVisibleSectionPosition(int firstVisibleItem, int visibleItemCount) {
 		ListAdapter adapter = getAdapter();
-		
-		if (firstVisibleItem + visibleItemCount >= adapter.getCount()) return -1; // dataset has changed, no candidate
-		
+
+        int adapterDataCount = adapter.getCount();
+        if (getLastVisiblePosition() >= adapterDataCount) return -1; // dataset has changed, no candidate
+
+        if (firstVisibleItem+visibleItemCount >= adapterDataCount){//added to prevent index Outofbound (in case)
+            visibleItemCount = adapterDataCount-firstVisibleItem;
+        }
+
 		for (int childIndex = 0; childIndex < visibleItemCount; childIndex++) {
 			int position = firstVisibleItem + childIndex;
 			int viewType = adapter.getItemViewType(position);


### PR DESCRIPTION
<img src="https://cloud.githubusercontent.com/assets/1631927/5648041/3b4f2cec-96c6-11e4-9349-5a0408331ee6.png" alt="" width=200/>

I noticed that findFirstVisibleSectionPosition() returns -1 when the listview is about reach the end. 
<code>firstVisibleItem+visibleItemCount >= adapter.getCount()</code>

This is just a quick fix until I can investigate further into the root cause of the problem.