### PR TITLE
Change layoutParams type to ViewGroup.LayoutParams

### DIFF
--- a/library/src/com/hb/views/PinnedSectionListView.java
+++ b/library/src/com/hb/views/PinnedSectionListView.java
@@ -196,10 +196,10 @@ public class PinnedSectionListView extends ListView {
 		View pinnedView = getAdapter().getView(position, pinnedShadow.view, PinnedSectionListView.this);
 
 		// read layout parameters
-		LayoutParams layoutParams = (LayoutParams) pinnedView.getLayoutParams();
+		ViewGroup.LayoutParams layoutParams = (ViewGroup.LayoutParams) pinnedView.getLayoutParams();
 		if (layoutParams == null) {
-		    layoutParams = (LayoutParams) generateDefaultLayoutParams();
-		    pinnedView.setLayoutParams(layoutParams);
+		        layoutParams = (ViewGroup.LayoutParams) generateDefaultLayoutParams();
+		        pinnedView.setLayoutParams(layoutParams);
 		}
 
 		int heightMode = MeasureSpec.getMode(layoutParams.height);


### PR DESCRIPTION
Solve issue #64 
Because pinnedView.getLayoutParams(), generateDefaultLayoutParams() return ViewGroup.LayoutParamsand not LayoutParams,
 we need to set type of layoutParams to ViewGroup.LayoutParams
